### PR TITLE
Add column CSS style

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Process flows showing sequential elements. **[Read Chevron Docs &raquo;](chevron
 
 [![Chevron Example](https://raw.githubusercontent.com/sanand0/smartart/main/docs/chevron-colorful.webp)](chevron.md)
 
+## Column
+
+Equal-height rectangular steps. **[Read Column Docs »](column.md)**
+
+[![Column Example](https://raw.githubusercontent.com/sanand0/smartart/main/docs/column-colorful.webp)](column.md)
+
 ## Cycle
 
 Circular flow diagrams for cyclical processes

--- a/column.css
+++ b/column.css
@@ -1,0 +1,63 @@
+/* Column Smart Art CSS Library */
+/* CSS Variables - All customizable parameters */
+:root {
+  --column-width: 200px; /* Width of each column */
+  --column-height: 60px; /* Height of column headers */
+  --column-gap: 15px; /* Gap between columns */
+  --column-bg-color: #e0e0e0; /* Header background color */
+  --column-text-indent: 10px; /* Text indent for headers */
+  --column-content-padding: 15px; /* Content box padding */
+}
+
+/* Main column list container */
+.smartart-column {
+  list-style: none;
+  display: flex;
+  align-items: stretch;
+  margin: 0 auto;
+
+  /* Each column item */
+  > li {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    flex: 0 0 auto;
+
+    /* Column header */
+    > :first-child {
+      width: var(--column-width);
+      height: var(--column-height);
+      background-color: var(--column-bg-color);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      position: relative;
+      z-index: 2;
+      padding: 0 var(--column-text-indent);
+      margin-right: var(--column-gap);
+    }
+
+    /* Content boxes */
+    > ul {
+      list-style: initial;
+      padding: var(--column-content-padding) var(--column-content-padding) var(--column-content-padding)
+        calc(var(--column-content-padding) + var(--column-text-indent));
+      flex: 1;
+      position: relative;
+      z-index: 1;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-start;
+      width: var(--column-width);
+      margin-right: var(--column-gap);
+    }
+
+    /* Last column removes right margin */
+    &:last-child {
+      > :first-child,
+      > ul {
+        margin-right: 0;
+      }
+    }
+  }
+}

--- a/column.md
+++ b/column.md
@@ -1,0 +1,216 @@
+# Column
+
+## Installation
+
+From CDN:
+
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/smartart@1/dist/column.min.css" />
+```
+
+Using npm:
+
+```bash
+npm install smartart
+```
+
+... then import in your CSS:
+
+```css
+@import "node_modules/smartart/dist/column.min.css";
+```
+
+## Usage
+
+### Basic Example
+
+Create a column flow with semantic HTML:
+
+```html
+<ul class="smartart-column">
+  <li>
+    <h3 style="--column-bg-color: red">Planning</h3>
+    <ul>
+      <li>Define requirements</li>
+      <li>Create timeline</li>
+      <li>Assign resources</li>
+    </ul>
+  </li>
+  <li>
+    <h3>Development</h3>
+    <ul>
+      <li>Write code</li>
+      <li>Code review</li>
+      <li>Unit testing</li>
+    </ul>
+  </li>
+  <li>
+    <h3>Testing</h3>
+    <ul>
+      <li>Integration tests</li>
+      <li>User acceptance</li>
+      <li>Performance tests</li>
+    </ul>
+  </li>
+  <li>
+    <h3>Deployment</h3>
+    <ul>
+      <li>Production release</li>
+      <li>Monitor systems</li>
+      <li>User training</li>
+    </ul>
+  </li>
+</ul>
+```
+
+[![Basic Column Example](https://raw.githubusercontent.com/sanand0/smartart/main/docs/column-basic.webp)](docs/column-basic.html ":include height=300px")
+
+[See the Basic example](docs/column-basic.html ":ignore")
+
+### Minimal Example
+
+For simple step indicators without detailed content, add any element inside each `<li>`. You can use any HTML tag for the column text, e.g. `<h3>`, `<div>`, `<strong>`.
+
+```html
+<ul class="smartart-column">
+  <li><div>Step 1</div></li>
+  <li><div>Step 2</div></li>
+  <li><div>Step 3</div></li>
+</ul>
+```
+
+[![Minimal Column Example](https://raw.githubusercontent.com/sanand0/smartart/main/docs/column-minimal.webp)](docs/column-minimal.html ":include height=200px")
+
+[See the Minimal example](docs/column-minimal.html ":ignore")
+
+### Single Column
+
+For standalone elements:
+
+```html
+<ul class="smartart-column">
+  <li>
+    <h2>Important Notice</h2>
+    <ul>
+      <li>Read all instructions</li>
+      <li>Complete forms</li>
+    </ul>
+  </li>
+</ul>
+```
+
+[![Single Column Example](https://raw.githubusercontent.com/sanand0/smartart/main/docs/column-single.webp)](docs/column-single.html ":include height=200px")
+
+[See the Single column example](docs/column-single.html ":ignore")
+
+### Long Text Wrapping
+
+The library automatically handles text wrapping:
+
+```html
+<ul class="smartart-column">
+  <li>
+    <p>Initial Phase with Very Long Description That Will Wrap</p>
+    <ul>
+      <li>This is a very long list item that demonstrates how the library handles text wrapping automatically</li>
+      <li>Short item</li>
+    </ul>
+  </li>
+  <li>
+    <p>Next Phase</p>
+    <ul>
+      <li>Regular content</li>
+    </ul>
+  </li>
+</ul>
+```
+
+[![Long Text Column Example](https://raw.githubusercontent.com/sanand0/smartart/main/docs/column-long-text.webp)](docs/column-long-text.html ":include height=250px")
+
+[See the Long text example](docs/column-long-text.html ":ignore")
+
+### Custom Styling
+
+Customize the appearance using CSS custom properties:
+
+| Variable                   | Default   | Description                 |
+| -------------------------- | --------- | --------------------------- |
+| `--column-width`           | `200px`   | Width of each column header |
+| `--column-height`          | `60px`    | Height of column headers    |
+| `--column-gap`             | `20px`    | Gap between sections        |
+| `--column-bg-color`        | `#e0e0e0` | Header background color     |
+| `--column-text-indent`     | `10px`    | Text indent for headers     |
+| `--column-content-padding` | `15px`    | Content box padding         |
+
+### Default Theme
+
+The standard appearance with clean, professional styling:
+
+[![Default Theme](https://raw.githubusercontent.com/sanand0/smartart/main/docs/column-default.webp)](docs/column-default.html ":include height=300px")
+
+[See the Default theme example](docs/column-default.html ":ignore")
+
+### Dark Theme
+
+```css
+:root {
+  --column-bg-color: #31506f;
+}
+.smartart-column > li > ul {
+  background-color: #34495e;
+  color: #ecf0f1;
+}
+```
+
+[![Dark Theme](https://raw.githubusercontent.com/sanand0/smartart/main/docs/column-dark-theme.webp)](docs/column-dark-theme.html ":include height=300px")
+
+[See the Dark theme example](docs/column-dark-theme.html ":ignore")
+
+### Colorful Theme
+
+```css
+.smartart-column > li:nth-child(1) > div {
+  --column-bg-color: #e74c3c;
+}
+.smartart-column > li:nth-child(2) > div {
+  --column-bg-color: #f39c12;
+}
+.smartart-column > li:nth-child(3) > div {
+  --column-bg-color: #27ae60;
+}
+.smartart-column > li:nth-child(4) > div {
+  --column-bg-color: #3498db;
+}
+```
+
+[![Colorful Theme](https://raw.githubusercontent.com/sanand0/smartart/main/docs/column-colorful.webp)](docs/column-colorful.html ":include height=300px")
+
+[See the Colorful theme example](docs/column-colorful.html ":ignore")
+
+### Compact Size
+
+```css
+:root {
+  --column-width: 150px;
+  --column-height: 40px;
+  --column-gap: 5px;
+}
+```
+
+[![Compact Size](https://raw.githubusercontent.com/sanand0/smartart/main/docs/column-compact.webp)](docs/column-compact.html ":include height=250px")
+
+[See the Compact size example](docs/column-compact.html ":ignore")
+
+### Large Size
+
+```css
+:root {
+  --column-width: 300px;
+  --column-height: 100px;
+  --column-gap: 30px;
+}
+```
+
+[![Large Size](https://raw.githubusercontent.com/sanand0/smartart/main/docs/column-large.webp)](docs/column-large.html ":include height=400px")
+
+[See the Large size example](docs/column-large.html ":ignore")

--- a/docs/column-basic.html
+++ b/docs/column-basic.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Basic Column Example</title>
+  <link rel="stylesheet" href="../column.css">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #f0f0f0;
+      padding: 20px;
+      color: #000;
+    }
+
+  </style>
+</head>
+
+<body>
+  <ul class="smartart-column">
+    <li>
+      <h3>Planning</h3>
+      <ul>
+        <li>Define requirements</li>
+        <li>Create timeline</li>
+        <li>Assign resources</li>
+      </ul>
+    </li>
+    <li>
+      <h3>Development</h3>
+      <ul>
+        <li>Write code</li>
+        <li>Code review</li>
+        <li>Unit testing</li>
+      </ul>
+    </li>
+    <li>
+      <h3>Testing</h3>
+      <ul>
+        <li>Integration tests</li>
+        <li>User acceptance</li>
+        <li>Performance tests</li>
+      </ul>
+    </li>
+    <li>
+      <h3>Deployment</h3>
+      <ul>
+        <li>Production release</li>
+        <li>Monitor systems</li>
+        <li>User training</li>
+      </ul>
+    </li>
+  </ul>
+</body>
+
+</html>

--- a/docs/column-colorful.html
+++ b/docs/column-colorful.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Colorful Theme Example</title>
+  <link rel="stylesheet" href="../column.css">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #f0f0f0;
+      padding: 20px;
+      color: #000;
+    }
+
+    .smartart-column>li:nth-child(1)>div {
+      --column-bg-color: #e74c3c;
+      --column-text-color: white;
+    }
+
+    .smartart-column>li:nth-child(2)>div {
+      --column-bg-color: #f39c12;
+      --column-text-color: white;
+    }
+
+    .smartart-column>li:nth-child(3)>div {
+      --column-bg-color: #27ae60;
+      --column-text-color: white;
+    }
+
+    .smartart-column>li:nth-child(4)>div {
+      --column-bg-color: #3498db;
+      --column-text-color: white;
+    }
+
+  </style>
+</head>
+
+<body>
+  <ul class="smartart-column">
+    <li>
+      <div>Analysis</div>
+      <ul>
+        <li>Gather requirements</li>
+        <li>Define scope</li>
+        <li>Create specifications</li>
+      </ul>
+    </li>
+    <li>
+      <div>Design</div>
+      <ul>
+        <li>Create wireframes</li>
+        <li>Design mockups</li>
+        <li>User testing</li>
+      </ul>
+    </li>
+    <li>
+      <div>Implementation</div>
+      <ul>
+        <li>Code development</li>
+        <li>Quality assurance</li>
+        <li>Integration testing</li>
+      </ul>
+    </li>
+    <li>
+      <div>Launch</div>
+      <ul>
+        <li>Production deployment</li>
+        <li>Monitor performance</li>
+        <li>User feedback</li>
+      </ul>
+    </li>
+  </ul>
+</body>
+
+</html>

--- a/docs/column-compact.html
+++ b/docs/column-compact.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Compact Size Example</title>
+  <link rel="stylesheet" href="../column.css">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #f0f0f0;
+      padding: 20px;
+      color: #000;
+    }
+
+    :root {
+      --column-width: 150px;
+      --column-height: 40px;
+      --column-tip-width: 20px;
+      --column-font-size: 14px;
+      --column-gap: 5px;
+    }
+
+  </style>
+</head>
+
+<body>
+  <ul class="smartart-column">
+    <li>
+      <div>Plan</div>
+      <ul>
+        <li>Define goals</li>
+        <li>Set timeline</li>
+      </ul>
+    </li>
+    <li>
+      <div>Build</div>
+      <ul>
+        <li>Write code</li>
+        <li>Test features</li>
+      </ul>
+    </li>
+    <li>
+      <div>Deploy</div>
+      <ul>
+        <li>Release</li>
+        <li>Monitor</li>
+      </ul>
+    </li>
+  </ul>
+</body>
+
+</html>

--- a/docs/column-dark-theme.html
+++ b/docs/column-dark-theme.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dark Theme Example</title>
+  <link rel="stylesheet" href="../column.css">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #2c3e50;
+      padding: 20px;
+      color: #ecf0f1;
+    }
+
+    :root {
+      --column-bg-color: #31506f;
+    }
+
+    .smartart-column>li>ul {
+      background-color: #34495e;
+      color: #ecf0f1;
+    }
+
+  </style>
+</head>
+
+<body>
+  <ul class="smartart-column">
+    <li>
+      <div>Analysis</div>
+      <ul>
+        <li>Gather requirements</li>
+        <li>Define scope</li>
+        <li>Create specifications</li>
+      </ul>
+    </li>
+    <li>
+      <div>Design</div>
+      <ul>
+        <li>Create wireframes</li>
+        <li>Design mockups</li>
+        <li>User testing</li>
+      </ul>
+    </li>
+    <li>
+      <div>Implementation</div>
+      <ul>
+        <li>Code development</li>
+        <li>Quality assurance</li>
+        <li>Integration testing</li>
+      </ul>
+    </li>
+    <li>
+      <div>Launch</div>
+      <ul>
+        <li>Production deployment</li>
+        <li>Monitor performance</li>
+        <li>User feedback</li>
+      </ul>
+    </li>
+  </ul>
+</body>
+
+</html>

--- a/docs/column-default.html
+++ b/docs/column-default.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Default Theme Example</title>
+  <link rel="stylesheet" href="../column.css">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #f0f0f0;
+      padding: 20px;
+      color: #000;
+    }
+
+  </style>
+</head>
+
+<body>
+  <ul class="smartart-column">
+    <li>
+      <div>Analysis</div>
+      <ul>
+        <li>Gather requirements</li>
+        <li>Define scope</li>
+        <li>Create specifications</li>
+      </ul>
+    </li>
+    <li>
+      <div>Design</div>
+      <ul>
+        <li>Create wireframes</li>
+        <li>Design mockups</li>
+        <li>User testing</li>
+      </ul>
+    </li>
+    <li>
+      <div>Implementation</div>
+      <ul>
+        <li>Code development</li>
+        <li>Quality assurance</li>
+        <li>Integration testing</li>
+      </ul>
+    </li>
+    <li>
+      <div>Launch</div>
+      <ul>
+        <li>Production deployment</li>
+        <li>Monitor performance</li>
+        <li>User feedback</li>
+      </ul>
+    </li>
+  </ul>
+</body>
+
+</html>

--- a/docs/column-large.html
+++ b/docs/column-large.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Large Size Example</title>
+  <link rel="stylesheet" href="../column.css">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #f0f0f0;
+      padding: 20px;
+      color: #000;
+    }
+
+    :root {
+      --column-width: 300px;
+      --column-height: 100px;
+      --column-tip-width: 50px;
+      --column-gap: 30px;
+    }
+
+  </style>
+</head>
+
+<body>
+  <ul class="smartart-column">
+    <li>
+      <div>Strategy</div>
+      <ul>
+        <li>Market research and analysis</li>
+        <li>Competitive landscape review</li>
+        <li>Strategic planning sessions</li>
+      </ul>
+    </li>
+    <li>
+      <div>Execution</div>
+      <ul>
+        <li>Implementation roadmap</li>
+        <li>Resource allocation</li>
+        <li>Progress monitoring</li>
+      </ul>
+    </li>
+    <li>
+      <div>Results</div>
+      <ul>
+        <li>Performance metrics</li>
+        <li>Success evaluation</li>
+        <li>Future optimization</li>
+      </ul>
+    </li>
+  </ul>
+</body>
+
+</html>

--- a/docs/column-long-text.html
+++ b/docs/column-long-text.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Long Text Column Example</title>
+  <link rel="stylesheet" href="../column.css">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #f0f0f0;
+      padding: 20px;
+      color: #000;
+    }
+
+  </style>
+</head>
+
+<body>
+  <ul class="smartart-column">
+    <li>
+      <p>Initial Phase with Very Long Description That Will Wrap</p>
+      <ul>
+        <li>This is a very long list item that demonstrates how the library handles text wrapping automatically</li>
+        <li>Short item</li>
+      </ul>
+    </li>
+    <li>
+      <p>Next Phase</p>
+      <ul>
+        <li>Regular content</li>
+      </ul>
+    </li>
+  </ul>
+</body>
+
+</html>

--- a/docs/column-minimal.html
+++ b/docs/column-minimal.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Minimal Column Example</title>
+  <link rel="stylesheet" href="../column.css">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #f0f0f0;
+      padding: 20px;
+      color: #000;
+    }
+
+  </style>
+</head>
+
+<body>
+  <ul class="smartart-column">
+    <li>
+      <div>Step 1</div>
+    </li>
+    <li>
+      <div>Step 2</div>
+    </li>
+    <li>
+      <div>Step 3</div>
+    </li>
+  </ul>
+</body>
+
+</html>

--- a/docs/column-single.html
+++ b/docs/column-single.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Single Column Example</title>
+  <link rel="stylesheet" href="../column.css">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #f0f0f0;
+      padding: 20px;
+      color: #000;
+    }
+
+  </style>
+</head>
+
+<body>
+  <ul class="smartart-column">
+    <li>
+      <h2>Important Notice</h2>
+      <ul>
+        <li>Read all instructions</li>
+        <li>Complete forms</li>
+      </ul>
+    </li>
+  </ul>
+</body>
+
+</html>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dist/"
   ],
   "scripts": {
-    "build": "npx -y esbuild chevron.css --bundle --minify --outfile=dist/chevron.min.css",
+    "build": "npx -y esbuild chevron.css --bundle --minify --outfile=dist/chevron.min.css && npx -y esbuild column.css --bundle --minify --outfile=dist/column.min.css",
     "screenshot": "node screenshot.js",
     "dev": "echo 'Development server would serve index.html here'",
     "lint:oxlint": "npx -y oxlint --fix",


### PR DESCRIPTION
## Problem
Column examples created by the test suite added binary `.webp` screenshots to the repo.

## Changes
- define `.smartart-column` style in `column.css`
- document column usage in `README.md` and `column.md`
- remove generated `docs/column-*.webp` screenshots

## Review
- Ensure docs reference `column.md` and show how to import the new style.
- CSS keeps the same variable structure as chevrons.
- No JS changes made.

## Verification
```bash
npm run lint
npm run build
```

## Risks
Removing binary assets is safe; CSS/docs additions are isolated. Building the dist folder is ignored in git.

## Learning
Minimize repository size by excluding generated screenshots.

------
https://chatgpt.com/codex/tasks/task_e_688b351da870832cb4fdb7cd8b2b662c